### PR TITLE
Minor quality of life change + build fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ contrib/adsabs/src/java/org/apache/lucene/queryparser/flexible/aqp/parser/ADSSyn
 contrib/antlrqueryparser/grammars/*Invenio.*
 contrib/adsabs/lib/*.jar
 lib/
+
+# ignore IDE-specific files
+**/.idea/

--- a/build.xml
+++ b/build.xml
@@ -283,7 +283,7 @@ solr.version=${solr.version}
 	</target>
 
 
-	<target name="check-solr-jars-exist" depends="check-solr-location" >
+	<target name="check-solr-jars-exist" depends="build-montysolr-dependencies" >
 		<!-- since on old ant we cannot ignore it -->
 		<mkdir dir="${solr.real.location}/dist" />
 		<mkdir dir="${build.dir}/solrjars-extracted" />


### PR DESCRIPTION
Fixes an issue in the `build.xml` file where Solr dependencies weren't being downloaded prior to extraction, producing build failures under certain versions of `ant`.