### PR TITLE
Change error for `pos` when used with a boolean query over multiple fields

### DIFF
--- a/montysolr/src/main/java/org/apache/lucene/queryparser/flexible/aqp/builders/AqpAdsabsSubQueryProvider.java
+++ b/montysolr/src/main/java/org/apache/lucene/queryparser/flexible/aqp/builders/AqpAdsabsSubQueryProvider.java
@@ -390,8 +390,8 @@ public class AqpAdsabsSubQueryProvider implements
                     }
 
                     if (s.size() > 1) {
-                        throw new SyntaxError("`pos` queries cannot handle boolean queries that span multiple fields; " + 
-                            "this includes virtual fields. Try using a non-virtual field instead.");
+                        throw new SyntaxError("`pos` queries cannot handle boolean queries that span multiple fields, " + 
+                            "including virtual field queries. Try using a non-virtual field instead.");
                     }
 
                     return (String) s.toArray()[0];

--- a/montysolr/src/main/java/org/apache/lucene/queryparser/flexible/aqp/builders/AqpAdsabsSubQueryProvider.java
+++ b/montysolr/src/main/java/org/apache/lucene/queryparser/flexible/aqp/builders/AqpAdsabsSubQueryProvider.java
@@ -388,9 +388,12 @@ public class AqpAdsabsSubQueryProvider implements
                     for (BooleanClause c : ((BooleanQuery) query).clauses()) {
                         s.add(getField(c.getQuery()));
                     }
+
                     if (s.size() > 1) {
-                        throw new SyntaxError("Illegal state: combining multiple fields is not allowed");
+                        throw new SyntaxError("`pos` queries cannot handle boolean queries that span multiple fields; " + 
+                            "this includes virtual fields. Try using a non-virtual field instead.");
                     }
+
                     return (String) s.toArray()[0];
                 } else {
                     // last resort


### PR DESCRIPTION
Changes the relatively inscrutable error message from `pos` when it's used with a boolean query over multiple fields (e.g. over a virtual field).

This change is a temporary resolution before we switch to broadcasting over each term in the boolean query.