### PR TITLE
Add `has` field to Solr schema

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -1387,6 +1387,11 @@
 			stored="true" multiValued="true" omitNorms="true"
 			omitTermFreqAndPositions="true" />
 
+		<field name="has"
+			type="normalized_text_ascii_notokenization" indexed="true"
+			stored="true" multiValued="true" omitNorms="true"
+			omitTermFreqAndPositions="true" />
+
 		<field name="database"
 			type="normalized_text_ascii_notokenization" indexed="true"
 			stored="true" multiValued="true" omitNorms="true"


### PR DESCRIPTION
# Intent
Introduce a multi-valued field has that will be populated with field names (like abstract, body, author) from a curated list that will get added when the Solr record in question has a non-empty entry for that field. For example, the query `has:abstract` returns all records that have an abstract.

# Implementation notes
- The `has` field is populated in the master pipeline, not at runtime.
- Not all schema fields are represented in the list of fields the pipeline fulfills.
- Solr does no validation of the user's input.