### PR TITLE
Remove acronym filter from `_nosyn` fields

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -664,15 +664,6 @@
 				<filter
 					class="org.apache.lucene.analysis.core.SelectiveLowerCaseFilterFactory" />
 
-
-
-				<!-- if the original or synonym contains UPPERCASE variant, mark it as 
-					an acronym but do not change its type, if it was a SYNONYM, it is important 
-					information for query parsing -->
-				<filter class="solr.AcronymTokenFilterFactory"
-					emitBoth="false" prefix="acr::" setType="ACRONYM" />
-
-
 				<!-- remove stop words - first the case sensitively -->
 				<filter
 					class="org.apache.lucene.analysis.core.AqpStopFilterFactory"


### PR DESCRIPTION
A user wanted to search for titles that have the acronym LBV. With the current schema `LBV` (in caps) triggers acronym expansion, even in exact searches.

This schema change removes acronym expansion for `_nosyn` fields, which are what the exact search converts all applicable fields to at query time.