### PR TITLE
Resolve test broken test case for version 77.2.1

### DIFF
--- a/montysolr/src/test/java/org/apache/solr/analysis/TestAdsabsTypeFulltextParsing.java
+++ b/montysolr/src/test/java/org/apache/solr/analysis/TestAdsabsTypeFulltextParsing.java
@@ -1189,7 +1189,7 @@ public class TestAdsabsTypeFulltextParsing extends MontySolrQueryTestCase {
         );
 
         assertQueryEquals(req("q", "=title:\"NGC 1\"", "defType", "aqp"),
-                "title:\"acr::ngc 1\"",
+                "title:\"ngc 1\"",
                 PhraseQuery.class);
         assertQ(req("q", "=title" + ":NGC 1"),
                 "//*[@numFound='4']",


### PR DESCRIPTION
v77.2.1 removed the acronym filter from `_nosyn` filters. One of the title text searches hard-coded the previous behavior; this PR modifies that test to align with the new exact search behavior.