### PR TITLE
Improve citation cache memory efficiency

### DIFF
--- a/montysolr/build.gradle.kts
+++ b/montysolr/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	java
 	antlr
+    kotlin("jvm") version "1.9.22"
 }
 
 repositories {
@@ -23,10 +24,16 @@ dependencies {
 	implementation("com.anyascii:anyascii:0.3.2")
 	implementation("org.python:jython-standalone:2.7.3")
 
+	implementation("me.lemire.integercompression:JavaFastPFOR:0.1.12")
+	implementation("it.unimi.dsi:fastutil-core:8.5.12")
+
 	testImplementation("junit:junit:4.13.2")
 	testImplementation("org.antlr:stringtemplate:3.2.1")
 	testImplementation("org.apache.solr:solr-test-framework:7.7.3")
 	testImplementation("org.apache.lucene:lucene-test-framework:7.7.3")
+
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-RC2")
+    testImplementation(kotlin("stdlib-jdk8"))
 }
 
 java {

--- a/montysolr/src/main/java/org/apache/solr/search/CitationLRUCache.java
+++ b/montysolr/src/main/java/org/apache/solr/search/CitationLRUCache.java
@@ -472,37 +472,11 @@ public class CitationLRUCache<K, V> extends SolrCacheBase implements CitationCac
 
         // collect ids of documents that need to be reloaded/regenerated during this
         // warmup run
-        // System.out.println("searcher: " + searcher.toString());
-        // System.out.println("maxDoc: " + searcher.getIndexReader().maxDoc());
         FixedBitSet toRefresh = new FixedBitSet(searcher.getIndexReader().maxDoc());
-
-        // System.out.println("version=" + searcher.getIndexReader().getVersion());
-        // try {
-        // System.out.println("commit=" + searcher.getIndexReader().getIndexCommit());
-        // } catch (IOException e2) {
-        // TODO Auto-generated catch block
-        // e2.printStackTrace();
-        // }
-
-        // for (IndexReaderContext c : searcher.getTopReaderContext().children()) {
-        // //System.out.println("context=" + c.reader().getCombinedCoreAndDeletesKey());
-        // }
-
-        // for (IndexReaderContext l : searcher.getIndexReader().leaves()) {
-        // //System.out.println(l);
-        // }
-
         Bits liveDocs = searcher.getSlowAtomicReader().getLiveDocs();
-        // System.out.println(liveDocs == null ? "liveDocs=" + null : "liveDocs=" +
-        // liveDocs.length());
-        // System.out.println("numDeletes=" +
-        // searcher.getAtomicReader().numDeletedDocs());
 
         if (liveDocs == null) { // everything is new, this could be fresh index or merged/optimized index too
 
-            // searcher.getAtomicReader().getContext().children().size()
-
-            // other.map.clear(); // force regeneration
             toRefresh.set(0, toRefresh.length());
 
             // Build the mapping from indexed values into lucene ids
@@ -516,17 +490,7 @@ public class CitationLRUCache<K, V> extends SolrCacheBase implements CitationCac
                 }
             });
 
-        } else if (liveDocs != null) {
-
-            Integer luceneId;
-            for (V v : other.relationships.values()) {
-                luceneId = ((Integer) v);
-                if (luceneId <= liveDocs.length() && !liveDocs.get(luceneId)) { // doc was either deleted or updated
-                    // System.out.println("Found deleted: " + luceneId);
-                    // retrieve all citations/references for this luceneId and mark these docs to be
-                    // refreshed
-                }
-            }
+        } else {
 
             for (int i = 0; i < toRefresh.length(); i++) {
                 if (liveDocs.get(i)) {

--- a/montysolr/src/test/java/org/apache/lucene/search/TestCitationsSearch.java
+++ b/montysolr/src/test/java/org/apache/lucene/search/TestCitationsSearch.java
@@ -150,8 +150,9 @@ public class TestCitationsSearch extends MontySolrAbstractTestCase {
             int docid = es.getKey();
             int[] docids = es.getValue();
             for (int reference : docids) {
-                List<Integer> a = Arrays.stream(citations.get(reference)).boxed().collect(Collectors.toList());
-                List<Integer> b = Arrays.stream(citationsWrapper.getLuceneDocIds(reference)).boxed().collect(Collectors.toList());
+                List<Integer> a = Arrays.stream(citations.get(reference)).boxed().sorted().collect(Collectors.toList());
+                List<Integer> b = Arrays.stream(citationsWrapper.getLuceneDocIds(reference)).boxed().sorted().collect(Collectors.toList());
+
                 assertTrue(a.contains(docid));
                 assertTrue(b.contains(docid));
                 assertEquals(a, b);
@@ -162,10 +163,9 @@ public class TestCitationsSearch extends MontySolrAbstractTestCase {
             int docid = es.getKey();
             int[] docids = es.getValue();
             for (int reference : docids) {
-                List<Integer> a = Arrays.stream(references.get(reference)).boxed().collect(Collectors.toList());
-                List<Integer> b = Arrays.stream(referencesWrapper.getLuceneDocIds(reference)).boxed().collect(Collectors.toList());
-                Collections.sort(a);
-                Collections.sort(b);
+                List<Integer> a = Arrays.stream(references.get(reference)).boxed().sorted().collect(Collectors.toList());
+                List<Integer> b = Arrays.stream(referencesWrapper.getLuceneDocIds(reference)).boxed().sorted().collect(Collectors.toList());
+
                 assertTrue(a.contains(docid));
                 assertTrue(b.contains(docid));
                 assertEquals(docid + " produced diff cache results", a, b);

--- a/montysolr/src/test/java/org/apache/solr/search/TestCitationCacheSolr.java
+++ b/montysolr/src/test/java/org/apache/solr/search/TestCitationCacheSolr.java
@@ -662,7 +662,7 @@ public class TestCitationCacheSolr extends MontySolrAbstractTestCase {
     @Test
     public void testRelationshipMap() throws Exception {
         CitationLRUCache.RelationshipLinkedHashMap<Object, Integer> map =
-                new CitationLRUCache.RelationshipLinkedHashMap<>(11, 0.75f, false, 1000, 0.75f);
+                new CitationLRUCache.RelationshipLinkedHashMap<>(11, 0.75f, false, 1000);
         map.initializeCitationCache(10);
 
         for (int i = 0; i < 10; i++) {

--- a/montysolr/src/test/java/org/apache/solr/search/TestCitationCacheSolr.java
+++ b/montysolr/src/test/java/org/apache/solr/search/TestCitationCacheSolr.java
@@ -618,17 +618,17 @@ public class TestCitationCacheSolr extends MontySolrAbstractTestCase {
 
             if (cacheName.contains("from-references")) {
                 int[][][] expected = new int[][][]{
-                        new int[][]{new int[]{3, 4, 2}, new int[0]},
+                        new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 10, 11}},
                         new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 9, 11}},
                         new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11}},
-                        new int[][]{new int[]{3, 4, 2}, new int[0]},
+                        new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[0], new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
-                        new int[][]{new int[]{4, 2, 2}, new int[0]},
+                        new int[][]{new int[]{2, 2, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                 };
 
@@ -637,9 +637,9 @@ public class TestCitationCacheSolr extends MontySolrAbstractTestCase {
                 int[][][] expected = new int[][][]{
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
-                        new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 9, 3, 4, 5, 6, 7, 10, 11, 2}},
-                        new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 9, 3, 4, 5, 6, 7, 11, 2}},
-                        new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 9, 3, 4, 5, 6, 7, 10, 11, 2}},
+                        new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11}},
+                        new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 9, 11}},
+                        new int[][]{new int[]{2, 3, 4}, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11}},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
                         new int[][]{new int[]{2, 3, 4}, new int[0]},
@@ -751,6 +751,9 @@ public class TestCitationCacheSolr extends MontySolrAbstractTestCase {
         int j = 0;
         while (it.hasNext()) {
             int[][] data = it.next();
+            Arrays.sort(data[0]);
+            Arrays.sort(data[1]);
+
             results[j] = data;
             j += 1;
         }


### PR DESCRIPTION
# Background
The citation "cache" functions as an in-memory graph containing all documents as nodes and citations/references as edges. It's used to speed up second order operators that rely on graph information.

Recently, we've been running into out of memory errors: the total citation graph for ~22 million documents was roughly 5GB in size. The graph is also duplicated in memory when the cache is being warmed by another Solr searcher, which can cause the graph to take >10GB of the 24GB allocated to Solr.

A decent amount of this space goes to "boxing" primitive values: when you box a primitive value, it's wrapped inside another object (the "box"). Each wrapper takes 2-4 bytes of memory, which can be substantial over 20 million values.

# Purpose
This PR reduces the size of the citation graph by using specialized primitive type collections that don't require boxing.

It also reduces the size of the graph by using maps instead of arrays to store relationships; previously we kept an array of size N, half of whose entries were `null`.