### PR TITLE
Change Montysolr build to use Java 11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/montysolr/build.gradle.kts
+++ b/montysolr/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
 java {
 	toolchain {
-		languageVersion.set(JavaLanguageVersion.of(8))
+		languageVersion.set(JavaLanguageVersion.of(11))
 	}
 }
 


### PR DESCRIPTION
We previously built Montysolr with Java 8 because there were various type errors at runtime.
This issue has been resolved.