### PR TITLE
Add `doctype_boost`

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -1539,7 +1539,7 @@
 	        qq={!aqp}black hole
 	        fq={!query v=$qq}
 	     -->
-		<field name="cite_read_boost" type="tfloat" indexed="true"
+		<field name="doctype_boost" type="tfloat" indexed="true"
 			stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
 
 		<!--

--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -1531,6 +1531,19 @@
 
 		<!--
 	    @api.doc
+	    * doctype_boost
+	      Float values containing normalized (float) boost factors. These
+	      can be used with functional queries to modify ranking of results.
+	      Example:
+	        q={!func}product(product(0.5,$scaledQ),product(0.5,field('doctype_boost')))
+	        qq={!aqp}black hole
+	        fq={!query v=$qq}
+	     -->
+		<field name="cite_read_boost" type="tfloat" indexed="true"
+			stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+		<!--
+	    @api.doc
 	    * cite_read_boost
 	      Float values containing normalized (float) boost factors. These
 	      can be used with functional queries to modify ranking of results.

--- a/montysolr/src/main/java/org/apache/lucene/queryparser/flexible/aqp/processors/AqpChangeRewriteMethodProcessor.java
+++ b/montysolr/src/main/java/org/apache/lucene/queryparser/flexible/aqp/processors/AqpChangeRewriteMethodProcessor.java
@@ -52,7 +52,7 @@ public class AqpChangeRewriteMethodProcessor extends
 
     protected QueryNode preProcessNode(QueryNode node) throws QueryNodeException {
 
-        if (first && getConfigVal("aqp.classic_scoring.modifier", "") != "") {
+        if (first && getConfigVal("aqp.classic_scoring.modifier", "").strip() != "") {
             // TODO: i don't want to make the source field be changed with URL params
             // but i'd like it to be configurable
 


### PR DESCRIPTION
# Why?

As SciX continues to expand into new domains we keep encountering papers outside of our well-established citation networks and read data. These metrics have worked well for astro papers, but tend to de-prioritize papers in new domains.

# What?

Adds support for the `doctype_boost` field in the schema, to be populated by the pipelines. This field is intended to be used with either the `sort` or `boost` query parameters to change document search rankings.

# Other notes

This PR builds on the Solr 9 release, which has not been merged (at the time this PR was originally published). The relevant commit in this branch changes `schema.xml`.