### PR TITLE
Disable the Citation Cache

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
@@ -145,6 +145,7 @@
     You can disable the cache/and cache-warming/ by setting the values
     to zero
      -->
+    <!--
     <cache name="citations-cache"
               class="solr.CitationLRUCache"
               size="${solr.citationCache.size:512}"
@@ -157,6 +158,7 @@
               dumpCache="${montysolr.enable.write:true}"
               loadDumpedCache="${montysolr.load.citation_cache:true}"
               />
+	    -->
               
     <enableLazyFieldLoading>true</enableLazyFieldLoading>
 
@@ -796,17 +798,21 @@
   <requestHandler name="/perf" class="perf.CreatePerformanceQueriesHandler">
   </requestHandler>
   
+  <!--
   <transformer name="citations" class="org.apache.solr.response.transform.CitationsTransformerFactory" >
     <str name="cache-name">citations-cache</str>
     <str name="resolution-field">bibcode</str>
   </transformer>
+	  -->
 
   <transformer name="fields" class="org.apache.solr.response.transform.FieldTransformerFactory" >
   </transformer>  
   
   <queryParser name="bitset" class="solr.search.BitSetQParserPlugin">
     <lst name="defaults">
+	    <!--
       <str name="cache-mapping">bibcode:citations-cache</str>
+	    -->
       <str name="allowed-fields">bibcode,recid</str>
     </lst>
   </queryParser>


### PR DESCRIPTION
⚠️ This PR is not meant to be merged ⚠️ 

# Why?

The citation cache takes up ~5GB resident memory per active index in a running Montysolr instance. This doubles during serialization and can cause Solr instances to OOM or go into a GC thrashing state due to a surfeit of small objects created for each query. This code change is what we deploy to our index nodes; as they don't need to serve citation queries, and indexing is already relatively taxing on system memory, removing the citation cache greatly reduces incidence of OOM crashes during the indexing process.

# What?

Very inelegantly removes the citation cache. This change as written causes crashes when citation queries are attempted without the cache (which probably shouldn't happen).