### PR TITLE
Prevent overly-greedy author name searches

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -146,7 +146,7 @@
 					p k *" "adamcuk, piotr k *" "adamcuk, p kolja *" "adamcuk," -->
 				<filter
 					class="solr.analysis.author.AuthorCreateQueryVariationsFilterFactory"
-					acronymVariations="1" plainSurname="true"
+					acronymVariations="1" plainSurname="false"
 					addShortenedMultiName="true" addWildcards="false"
 					lookAtPayloadForOrigAuthor="false" />
 				<!-- deal with multiple occurences of the same (can happen because of 
@@ -211,7 +211,7 @@
 					p k *" "adamcuk, piotr k *" "adamcuk, p kolja *" "adamcuk," -->
 				<filter
 					class="solr.analysis.author.AuthorCreateQueryVariationsFilterFactory"
-					acronymVariations="1" plainSurname="true"
+					acronymVariations="1" plainSurname="false"
 					addShortenedMultiName="true" addWildcards="false"
 					lookAtPayloadForOrigAuthor="false" />
 				<!-- deal with multiple occurences of the same (can happen because of 
@@ -278,7 +278,7 @@
 					p k *" "adamcuk, piotr k *" "adamcuk, p kolja *" "adamcuk," -->
 				<filter
 					class="solr.analysis.author.AuthorCreateQueryVariationsFilterFactory"
-					acronymVariations="1" plainSurname="true"
+					acronymVariations="1" plainSurname="false"
 					addShortenedMultiName="true" addWildcards="false"
 					lookAtPayloadForOrigAuthor="false" />
 				<!-- deal with multiple occurences of the same (can happen because of 
@@ -371,7 +371,7 @@
 					p k *" "adamcuk, piotr k *" "adamcuk, p kolja *" "adamcuk," -->
 				<filter
 					class="solr.analysis.author.AuthorCreateQueryVariationsFilterFactory"
-					acronymVariations="1" plainSurname="true"
+					acronymVariations="1" plainSurname="false"
 					addShortenedMultiName="true" addWildcards="false"
 					lookAtPayloadForOrigAuthor="false" />
 				<!-- deal with multiple occurences of the same (can happen because of 

--- a/montysolr/src/main/java/org/apache/solr/analysis/author/PythonicAuthorNormalizerFilter.java
+++ b/montysolr/src/main/java/org/apache/solr/analysis/author/PythonicAuthorNormalizerFilter.java
@@ -64,7 +64,7 @@ public final class PythonicAuthorNormalizerFilter extends TokenFilter {
         for (String individual : original.split(";")) {
 
             // skip processing wildcards
-            if (individual.indexOf('*') > -1 || individual.indexOf('?') > -1) {
+            if (individual.contains("*") || individual.contains("?")) {
                 buffer.add(individual);
                 continue;
             }
@@ -103,7 +103,7 @@ public final class PythonicAuthorNormalizerFilter extends TokenFilter {
                 } else { // some modifications happened
 
                     // add original
-                    if (individual.indexOf(",") == -1) {
+                    if (!individual.contains(",")) {
                         buffer.add(individual + ",");
                     } else {
                         buffer.add(individual);


### PR DESCRIPTION
# What?

Prevents author names from expanding into bare surnames ("Anna Kelbert" -> "Kelbert,").

# Why?

When author names expand to bare surnames, it can produce overly greedy searches that include miscellaneous authors unrelated to the original search. This is especially bad for common author names.