### PR TITLE
Add config option to control max highlight length

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
@@ -556,7 +556,7 @@
 
 
   <searchComponent class="solr.HighlightComponent" name="highlight">
-    <highlighting>
+    <highlighting class="org.apache.solr.highlight.MaxLengthHighlighter">
       <!-- Configure the standard fragmenter -->
       <!-- This could most likely be commented out in the "default" case -->
       <fragmenter name="gap" 

--- a/montysolr/build.gradle.kts
+++ b/montysolr/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 	implementation("org.apache.lucene:lucene-join:9.10.0")
 	implementation("org.apache.lucene:lucene-misc:9.10.0")
 	implementation("org.apache.lucene:lucene-suggest:9.10.0")
+	implementation("org.apache.lucene:lucene-highlighter:9.10.0")
 	implementation("org.apache.commons:commons-lang3:3.14.0")
 
 	implementation("com.google.guava:guava:33.2.1-jre")

--- a/montysolr/src/main/java/org/apache/solr/highlight/MaxLengthHighlighter.java
+++ b/montysolr/src/main/java/org/apache/solr/highlight/MaxLengthHighlighter.java
@@ -1,0 +1,66 @@
+package org.apache.solr.highlight;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.uhighlight.UnifiedHighlighter;
+import org.apache.solr.common.params.HighlightParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.search.DocList;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+public class MaxLengthHighlighter extends UnifiedSolrHighlighter {
+
+    public final String MAX_HIGHLIGHT_CHARACTERS = "hl.maxHighlightCharacters";
+
+    @Override
+    public NamedList<Object> doHighlighting(DocList docs, Query query, SolrQueryRequest req, String[] defaultFields) throws IOException {
+        final SolrParams params = req.getParams();
+
+        // if highlighting isn't enabled, then why call doHighlighting?
+        if (!isHighlightingEnabled(params)) return null;
+
+        int[] docIDs = toDocIDs(docs);
+
+        // fetch the unique keys
+        String[] keys = getUniqueKeys(req.getSearcher(), docIDs);
+
+        // query-time parameters
+        String[] fieldNames = getHighlightFields(query, req, defaultFields);
+
+        int maxPassages[] = new int[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; i++) {
+            maxPassages[i] = params.getFieldInt(fieldNames[i], HighlightParams.SNIPPETS, 1);
+        }
+
+        UnifiedHighlighter highlighter = getHighlighter(req);
+        Map<String, String[]> snippets =
+                fieldNames.length == 0
+                        ? Collections.emptyMap()
+                        : highlighter.highlightFields(fieldNames, query, docIDs, maxPassages);
+
+        int maxLength = params.getInt(MAX_HIGHLIGHT_CHARACTERS, -1);
+        if (maxLength >= 0) {
+            for (String key : snippets.keySet()) {
+                String[] highlights = snippets.get(key);
+                if (highlights == null) continue;
+
+                int count = 0;
+                for (int index = 0; index < highlights.length; index++) {
+                    if (highlights[index] != null) {
+                        if (count > maxLength) {
+                            highlights[index] = null;
+                        } else {
+                            count += highlights[index].length();
+                        }
+                    }
+                }
+            }
+        }
+
+        return encodeSnippets(keys, fieldNames, snippets);
+    }
+}

--- a/montysolr/src/main/java/org/apache/solr/highlight/MaxLengthHighlighter.java
+++ b/montysolr/src/main/java/org/apache/solr/highlight/MaxLengthHighlighter.java
@@ -48,13 +48,10 @@ public class MaxLengthHighlighter extends UnifiedSolrHighlighter {
                 String[] highlights = snippets.get(key);
                 if (highlights == null) continue;
 
-                int count = 0;
                 for (int index = 0; index < highlights.length; index++) {
                     if (highlights[index] != null) {
-                        if (count > maxLength) {
+                        if (highlights[index].length() > maxLength) {
                             highlights[index] = null;
-                        } else {
-                            count += highlights[index].length();
                         }
                     }
                 }


### PR DESCRIPTION
As part of our agreement with publishers we set a maximum character length for highlights. This was loosely enforced using other highlighter parameters, but the unified highlighter does not support a fixed max length for all highlights-- we need an alternate enforcement mechanism.

This PR adds a highlighter with a new parameter to control the max highlight length coming from the searcher.

An alternative implementation might live in `solr-service` as we're not doing any advanced processing in Solr.