### PR TITLE
Enable changing max boolean clause count via system property

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
@@ -111,7 +111,7 @@
        Query section - these settings control query time things like caches
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   <query>
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
     
     <slowQueryThresholdMillis>1000</slowQueryThresholdMillis>
 


### PR DESCRIPTION
# What?

Adds the option to configure the max clause count via a system property (typically set via the command line).

# Why?

We've had issues with author searches hitting the max clause limit. For our use-case it makes sense to increase this limit and _also_ set a timeout for all requests.