### PR TITLE
Add timeAllowed as a default query parameter

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
@@ -302,6 +302,7 @@
      <lst name="defaults">
        <str name="wt">json</str>
        <int name="rows">10</int>
+       <int name="timeAllowed">${solr.max.timeAllowed:10000}</int>
        <str name="fl">id recid title abstract author bibcode identifier volume page bibstem doctype pubdate pub pub_raw citation_count read_count esources</str>
        <!-- 
        ADSLABS:12/12: this can be overrided by url params. 
@@ -353,6 +354,7 @@
     <lst name="defaults">
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
+       <int name="timeAllowed">${solr.max.timeAllowed:10000}</int>
        <str name="qf">first_author^0.9 author^0.85 year^0.8 title^0.8 abstract^0.7 identifier^0.8 bibstem^0.8 keyword^0.8</str>
        <str name="defType">aqp</str>
        <str name="aqp.unfielded.tokens.strategy">disjuncts</str>
@@ -400,6 +402,7 @@
      <lst name="defaults">
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
+       <int name="timeAllowed">${solr.max.timeAllowed:10000}</int>
        <str name="wt">json</str>
        <str name="indent">true</str>
        <!-- 
@@ -527,6 +530,7 @@
     <lst name="defaults">
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
+       <int name="timeAllowed">${solr.max.timeAllowed:10000}</int>
        <str name="qf">first_author^5 author^2 title^1.5 abstract^1.3 identifier^1 bibstem^1 year^2</str>
        <str name="defType">aqp</str>
        <str name="aqp.unfielded.tokens.strategy">disjuncts</str>


### PR DESCRIPTION
## What?

Adds `timeAllowed` as a default query parameter. This allows us to control the maximum amount of time a query may spend before being evicted from the searcher core.

## Why?

Some longer queries have the ability to take down the entire searcher. This, hopefully, will help to resolve that issue.