### PR TITLE
Update the schema to include `reference_count`

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -1674,6 +1674,10 @@
 		<field name="read_count" type="int" indexed="true" stored="true"
 			omitNorms="true" omitTermFreqAndPositions="true" docValues="true" />
 
+		<field name="reference_count" type="int" indexed="true"
+			   stored="true" omitNorms="true" omitTermFreqAndPositions="true"
+			   docValues="true" />
+
 		<!-- technical metadata; values are a JSON string that is stored and used 
 			for search result display -->
 		<field name="links_data" type="string" indexed="false"


### PR DESCRIPTION
This field was added to assist the frontend in removing the [citations] document transform as a dependency; the transform was based on the citation cache, which we're working to remove from Solr entirely.