### PR TITLE
Enable other identifiers in bitset query parser

### DIFF
--- a/montysolr/src/main/java/org/apache/solr/search/BitSetQParserPlugin.java
+++ b/montysolr/src/main/java/org/apache/solr/search/BitSetQParserPlugin.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.Function;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -355,25 +356,30 @@ public class BitSetQParserPlugin extends QParserPlugin {
             // for csv, we can assume that every doc has the same fields (?)
             Iterator<SolrInputField> fi = d.iterator();
 
-            HashMap<String, SolrCacheWrapper<CitationCache<Object, Integer>>> translators = new HashMap<String, SolrCacheWrapper<CitationCache<Object, Integer>>>();
+            HashMap<String, Function<Object, Integer>> translators = new HashMap<>();
 
             while (fi.hasNext()) {
                 SolrInputField field = fi.next();
+                Function<Object, Integer> docIdResolver = null;
                 SolrCacheWrapper<CitationCache<Object, Integer>> cache = getCache(field.getName());
                 if (cache == null) {
                     throw new SolrException(ErrorCode.BAD_REQUEST, "Uff, uff, I have no idea how to map this field (" + field.getName() + ") values into docids! Call 911");
+                } else {
+                    docIdResolver = obj -> cache.getLuceneDocId(0, obj);
                 }
-                translators.put(field.getName(), cache);
+                translators.put(field.getName(), docIdResolver);
             }
 
             for (SolrInputDocument doc : docs) {
-                for (SolrInputField f : doc.values()) {
-                    SolrCacheWrapper<CitationCache<Object, Integer>> c = translators.get(f.getName());
-                    for (Object o : f.getValues()) {
-                        int v = c.getLuceneDocId(0, o);
-                        if (v == -1)
+                for (SolrInputField queryField : doc.values()) {
+                    Function<Object, Integer> docIdMapper = translators.get(queryField.getName());
+
+                    for (Object queryFieldValue : queryField.getValues()) {
+                        int luceneId = docIdMapper.apply(queryFieldValue);
+                        if (luceneId == -1)
                             continue;
-                        bs.set(v);
+
+                        bs.set(luceneId);
                     }
                 }
             }

--- a/montysolr/src/test/java/org/apache/solr/search/TestBitSetQParserPlugin.java
+++ b/montysolr/src/test/java/org/apache/solr/search/TestBitSetQParserPlugin.java
@@ -36,7 +36,7 @@ public class TestBitSetQParserPlugin extends MontySolrAbstractTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        schemaString = "solr/collection1/conf/schema-minimal.xml";
+        schemaString = "solr/collection1/conf/schema-bitset.xml";
 
         configString = "solr/collection1/conf/bitset-solrconfig.xml";
 
@@ -45,18 +45,18 @@ public class TestBitSetQParserPlugin extends MontySolrAbstractTestCase {
 
 
     public void createIndex() {
-        assertU(adoc("id", "1", "recid", "1", "text", "who"));
-        assertU(adoc("id", "2", "recid", "2", "text", "is stopword"));
-        assertU(adoc("id", "3", "recid", "3", "text", "able"));
-        assertU(adoc("id", "4", "recid", "4", "text", "to stopword"));
-        assertU(adoc("id", "5", "recid", "5", "text", "exchange"));
+        assertU(adoc("id", "1", "recid", "1", "strid", "a", "text", "who"));
+        assertU(adoc("id", "2", "recid", "2", "strid", "b", "text", "is stopword"));
+        assertU(adoc("id", "3", "recid", "3", "strid", "c", "text", "able"));
+        assertU(adoc("id", "4", "recid", "4", "strid", "d", "text", "to stopword"));
+        assertU(adoc("id", "5", "recid", "5", "strid", "e", "text", "exchange"));
         assertU(commit("waitSearcher", "true"));
 
-        assertU(adoc("id", "16", "recid", "16", "text", "liberty"));
-        assertU(adoc("id", "17", "recid", "17", "text", "for stopword"));
-        assertU(adoc("id", "18", "recid", "18", "text", "safety"));
-        assertU(adoc("id", "19", "recid", "19", "text", "deserves"));
-        assertU(adoc("id", "20", "recid", "20", "text", "neither"));
+        assertU(adoc("id", "16", "recid", "16", "strid", "f", "text", "liberty"));
+        assertU(adoc("id", "17", "recid", "17", "strid", "g", "text", "for stopword"));
+        assertU(adoc("id", "18", "recid", "18", "strid", "h", "text", "safety"));
+        assertU(adoc("id", "19", "recid", "19", "strid", "i", "text", "deserves"));
+        assertU(adoc("id", "20", "recid", "20", "strid", "j", "text", "neither"));
         assertU(commit("waitSearcher", "true"));
     }
 
@@ -64,6 +64,22 @@ public class TestBitSetQParserPlugin extends MontySolrAbstractTestCase {
     public void setUp() throws Exception {
         super.setUp();
         createIndex();
+    }
+
+    public void testStringIDs() throws Exception {
+        SolrQueryRequestBase req = (SolrQueryRequestBase) req("q", "text:*",
+                "fq", "{!bitset compression=none}");
+        List<ContentStream> streams = new ArrayList<ContentStream>(1);
+        ContentStreamBase cs = new ContentStreamBase.StringStream("strid\na\nb");
+        cs.setContentType("big-query/csv");
+        streams.add(cs);
+        req.setContentStreams(streams);
+
+        assertQ(req
+                , "//*[@numFound='2']",
+                "//doc/str[@name='id'][.='5']",
+                "//doc/str[@name='id'][.='16']"
+        );
     }
 
     @Test

--- a/montysolr/src/test/resources/solr/collection1/conf/schema-bitset.xml
+++ b/montysolr/src/test/resources/solr/collection1/conf/schema-bitset.xml
@@ -16,7 +16,7 @@
     <fields>
         <field name="id" type="string" indexed="true" stored="true"/>
         <field name="recid" type="int" indexed="true" stored="true"/>
-        <field name="strid" type="identifier_string" indexed="true" stored="true"/>
+        <field name="strid" type="identifier_string" multiValued="true" indexed="true" stored="true"/>
         <dynamicField name="*" type="text_ws" indexed="true" stored="true"/>
     </fields>
     <uniqueKey>id</uniqueKey>

--- a/montysolr/src/test/resources/solr/collection1/conf/schema-bitset.xml
+++ b/montysolr/src/test/resources/solr/collection1/conf/schema-bitset.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema name="minimal" version="1.1">
+    <types>
+        <fieldType name="string" class="solr.StrField"/>
+        <fieldType name="int" class="solr.TrieIntField"
+                   precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+        <fieldType name="identifier_string"
+                   class="solr.SortableTextField"/>
+        <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="1">
+            <analyzer>
+                <tokenizer class="solr.StandardTokenizerFactory"/>
+                <filter class="solr.LowerCaseFilterFactory"/>
+            </analyzer>
+        </fieldType>
+    </types>
+    <fields>
+        <field name="id" type="string" indexed="true" stored="true"/>
+        <field name="recid" type="int" indexed="true" stored="true"/>
+        <field name="strid" type="identifier_string" indexed="true" stored="true"/>
+        <dynamicField name="*" type="text_ws" indexed="true" stored="true"/>
+    </fields>
+    <uniqueKey>id</uniqueKey>
+</schema>


### PR DESCRIPTION
# What?

This enables any field to be used with the bitset query parser via the CSV format parser. Any values passed in will be looked up, one at a time, to locate the first doc matching each.
> [!WARNING]
> Searching for non-unique values will produce non-exhaustive bitsets.

# Why?

Not all records have bibcodes and we'd like the flexibility to use other identifiers. In particular, we're moving towards using [SciX IDs, an internal ID representation](https://docs.google.com/document/d/1fKua6x-by0vfpu6yarUm1f0Z2QD2YVKTtpNbVbD7gAw), for all of our infrastructure.