### PR TITLE
Add Boost Fields

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -1559,6 +1559,33 @@
 		<field name="doctype_boost" type="tfloat" indexed="true"
 			stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
 
+        <field name="refereed_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="recency_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="boost_factor" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="astronomy_final_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="physics_final_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="earth_science_final_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="planetary_science_final_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="heliophysics_final_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
+        <field name="general_final_boost" type="tfloat" indexed="true"
+               stored="true" omitNorms="true" omitTermFreqAndPositions="true" />
+
 		<!--
 	    @api.doc
 	    * cite_read_boost

--- a/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/solrconfig.xml
@@ -758,7 +758,7 @@
        <str name="aqp.dateFields">entry_date,date</str>
        <str name="aqp.timestampFields">indexstamp,update_timestamp,entry_date,metadata_ctime,metadata_mtime,fulltext_ctime,fulltext_mtime,nonbib_ctime,nonbib_mtime,metrics_ctime,metrics_mtime,orcid_ctime,orcid_mtime</str>
        <str name="aqp.floatFields">cite_read_boost,citation_count_norm</str>
-       <str name="aqp.intFields">recid,pubdate_sort,citation_count,classic_factor,simbid,uat_id,read_count,author_count,page_count,data_count</str>
+       <str name="aqp.intFields">recid,pubdate_sort,citation_count,classic_factor,simbid,uat_id,read_count,author_count,page_count,data_count,mention_count,credit_count</str>
        <str name="aqp.authorFields">author,first_author,book_author,editor</str>
        <str name="aqp.humanized.dates">pubdate:date,entdate:entry_date:timestamp</str>
        <str name="aqp.force.fuzzy.phrases">author,first_author,book_author,editor</str>
@@ -837,7 +837,7 @@
        <str name="aqp.dateFields">entry_date,date</str>
        <str name="aqp.timestampFields">indexstamp,update_timestamp,entry_date,metadata_ctime,metadata_mtime,fulltext_ctime,fulltext_mtime,nonbib_ctime,nonbib_mtime,metrics_ctime,metrics_mtime,orcid_ctime,orcid_mtime</str>
        <str name="aqp.floatFields">cite_read_boost,citation_count_norm</str>
-       <str name="aqp.intFields">recid,pubdate_sort,citation_count,classic_factor,simbid,uat_id,read_count,author_count,page_count,data_count</str>
+       <str name="aqp.intFields">recid,pubdate_sort,citation_count,classic_factor,simbid,uat_id,read_count,author_count,page_count,data_count,mention_count,credit_count</str>
        <str name="aqp.authorFields">author,first_author,book_author,editor</str>
        <str name="aqp.humanized.dates">pubdate:date,entdate:entry_date:timestamp</str>
        <str name="aqp.force.fuzzy.phrases">author,first_author,book_author,editor</str>


### PR DESCRIPTION
# What?
Adds fields to the schema to be used with boost functions.

# Why?
We'd like to provide different document rankings per discipline we support. These boost factors will be dynamically swapped in to re-weight records based on the user's indicated discipline preference.