### PR TITLE
Fix normalized_text_ascii regex

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -807,7 +807,7 @@
 				<filter class="solr.ASCIIFoldingFilterFactory" />
 				<filter class="solr.LowerCaseFilterFactory" />
 				<filter class="solr.PatternReplaceFilterFactory"
-					pattern="(\-\.|_)" replacement="" replace="all" />
+					pattern="(\-|\.|_)" replacement="" replace="all" />
 				<filter
 					class="org.apache.lucene.analysis.miscellaneous.RemoveDuplicatesTokenFilterFactory" />
 			</analyzer>
@@ -816,7 +816,7 @@
 				<filter class="solr.ASCIIFoldingFilterFactory" />
 				<filter class="solr.LowerCaseFilterFactory" />
 				<filter class="solr.PatternReplaceFilterFactory"
-					pattern="(\-\.|_)" replacement="" replace="all" />
+					pattern="(\-|\.|_)" replacement="" replace="all" />
 			</analyzer>
 		</fieldType>
 


### PR DESCRIPTION
Fixes a broken regex in `normalized_text_ascii` that prevents orcids from matching.