### PR TITLE
Update field "pub" to type "normalized_string"

### DIFF
--- a/deploy/adsabs/server/solr/collection1/conf/schema.xml
+++ b/deploy/adsabs/server/solr/collection1/conf/schema.xml
@@ -1169,7 +1169,7 @@
 	    * version
 	      initially asclepias version, available to be used more widely
 	     -->
-		<field name="pub" type="normalized_text_ascii" indexed="true"
+		<field name="pub" type="normalized_string" indexed="true"
 			stored="true" omitNorms="true" />
 
 		<field name="pub_raw" type="normalized_text_ascii"


### PR DESCRIPTION
# Why?

We desire exact matches over the `pub` field vs the current substring matching status quo.

Per the Jira ticket:

> Right now, the pub field is performing substring searches, e.g. pub:Nature returns publications from Nature Astronomy, Nature Medicine, and Nature Materials, in addition to just plain old Nature. The goal is for pub:Nature to only find publications from Nature, i.e. the entire field must be matched in the search.
> 
> This will be coupled with an autocomplete on the pub field on the UI side. Substring search capabilities will be retained by searching the pub_raw field.

# What?

Changes the field type of `pub` to `normalized_string` from `normalized_text_ascii`. `normalized_string` uses a KeywordTokenizer, vs the WhitespaceTokenizer used in `normalized_text_ascii`. With this change we will only match `pub` queries to exact string matches (e.g. "Nature" will not match "Nature Medicine" anymore).